### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Mac Apps Launcher MCP Server
+[![smithery badge](https://smithery.ai/badge/@joshuarileydev/mac-apps-launcher-mcp-server)](https://smithery.ai/server/@joshuarileydev/mac-apps-launcher-mcp-server)
 
 A Model Context Protocol (MCP) server for launching and managing macOS applications.
 
@@ -9,6 +10,16 @@ A Model Context Protocol (MCP) server for launching and managing macOS applicati
 - Open files with specific applications
 
 ## Installation
+
+### Installing via Smithery
+
+To install Mac Apps Launcher for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@joshuarileydev/mac-apps-launcher-mcp-server):
+
+```bash
+npx -y @smithery/cli install @joshuarileydev/mac-apps-launcher-mcp-server --client claude
+```
+
+### Installing Manually
 Add the following to your Claude Config JSON file
 ```
 {


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Mac Apps Launcher for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@joshuarileydev/mac-apps-launcher-mcp-server

Let me know if any tweaks have to be made!